### PR TITLE
generate swagger for current model

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1,0 +1,3808 @@
+{
+	"swagger": "2.0",
+	"info": {
+		"contact": {
+			"name": "kubeflow.org",
+			"url": "https://kubeflow.org"
+		},
+		"license": {
+			"name": "Apache 2.0",
+			"url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+		},
+		"version": "v1alpha2"
+	},
+	"paths": {
+		"/apis/": {
+			"get": {
+				"description": "get available API versions",
+				"consumes": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf"
+				],
+				"produces": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf"
+				],
+				"schemes": [
+					"https"
+				],
+				"tags": [
+					"apis"
+				],
+				"operationId": "getAPIVersions",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList"
+						}
+					}
+				}
+			}
+		},
+		"/apis/kubeflow.org/": {
+			"get": {
+				"description": "get information of a group",
+				"consumes": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf"
+				],
+				"produces": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf"
+				],
+				"schemes": [
+					"https"
+				],
+				"tags": [
+					"kubeflowOrg"
+				],
+				"operationId": "getKubeflowOrgAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+						}
+					}
+				}
+			}
+		},
+		"/apis/kubeflow.org/v1alpha2/": {
+			"get": {
+				"description": "get available resources",
+				"consumes": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf"
+				],
+				"produces": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf"
+				],
+				"schemes": [
+					"https"
+				],
+				"tags": [
+					"kubeflowOrg_v1alpha2"
+				],
+				"operationId": "getKubeflowOrgV1alpha2APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+						}
+					}
+				}
+			}
+		},
+		"/apis/kubeflow.org/v1alpha2/namespaces/{namespace}/tfjobs": {
+			"get": {
+				"description": "list or watch objects of kind TFJob",
+				"consumes": [
+					"*/*"
+				],
+				"produces": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf",
+					"application/json;stream=watch",
+					"application/vnd.kubernetes.protobuf;stream=watch"
+				],
+				"schemes": [
+					"https"
+				],
+				"tags": [
+					"kubeflowOrg_v1alpha2"
+				],
+				"operationId": "listKubeflowOrgV1alpha2NamespacedTFJob",
+				"parameters": [
+					{
+						"uniqueItems": true,
+						"type": "string",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"name": "continue",
+						"in": "query"
+					},
+					{
+						"uniqueItems": true,
+						"type": "string",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"name": "fieldSelector",
+						"in": "query"
+					},
+					{
+						"uniqueItems": true,
+						"type": "boolean",
+						"description": "If true, partially initialized resources are included in the response.",
+						"name": "includeUninitialized",
+						"in": "query"
+					},
+					{
+						"uniqueItems": true,
+						"type": "string",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"name": "labelSelector",
+						"in": "query"
+					},
+					{
+						"uniqueItems": true,
+						"type": "integer",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"name": "limit",
+						"in": "query"
+					},
+					{
+						"uniqueItems": true,
+						"type": "string",
+						"description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history. When specified for list: - if unset, then the result is returned from remote storage based on quorum-read flag; - if it's 0, then we simply return what we currently have in cache, no guarantee; - if set to non zero, then the result is at least as fresh as given rv.",
+						"name": "resourceVersion",
+						"in": "query"
+					},
+					{
+						"uniqueItems": true,
+						"type": "integer",
+						"description": "Timeout for the list/watch call.",
+						"name": "timeoutSeconds",
+						"in": "query"
+					},
+					{
+						"uniqueItems": true,
+						"type": "boolean",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"name": "watch",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJobList"
+						}
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "kubeflow.org",
+					"version": "v1alpha2",
+					"kind": "TFJob"
+				}
+			},
+			"post": {
+				"description": "create a TFJob",
+				"consumes": [
+					"*/*"
+				],
+				"produces": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf"
+				],
+				"schemes": [
+					"https"
+				],
+				"tags": [
+					"kubeflowOrg_v1alpha2"
+				],
+				"operationId": "createKubeflowOrgV1alpha2NamespacedTFJob",
+				"parameters": [
+					{
+						"name": "body",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJob"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJob"
+						}
+					},
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJob"
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"schema": {
+							"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJob"
+						}
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "kubeflow.org",
+					"version": "v1alpha2",
+					"kind": "TFJob"
+				}
+			},
+			"delete": {
+				"description": "delete collection of TFJob",
+				"consumes": [
+					"*/*"
+				],
+				"produces": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf"
+				],
+				"schemes": [
+					"https"
+				],
+				"tags": [
+					"kubeflowOrg_v1alpha2"
+				],
+				"operationId": "deleteKubeflowOrgV1alpha2CollectionNamespacedTFJob",
+				"parameters": [
+					{
+						"uniqueItems": true,
+						"type": "string",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"name": "continue",
+						"in": "query"
+					},
+					{
+						"uniqueItems": true,
+						"type": "string",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"name": "fieldSelector",
+						"in": "query"
+					},
+					{
+						"uniqueItems": true,
+						"type": "boolean",
+						"description": "If true, partially initialized resources are included in the response.",
+						"name": "includeUninitialized",
+						"in": "query"
+					},
+					{
+						"uniqueItems": true,
+						"type": "string",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"name": "labelSelector",
+						"in": "query"
+					},
+					{
+						"uniqueItems": true,
+						"type": "integer",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"name": "limit",
+						"in": "query"
+					},
+					{
+						"uniqueItems": true,
+						"type": "string",
+						"description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history. When specified for list: - if unset, then the result is returned from remote storage based on quorum-read flag; - if it's 0, then we simply return what we currently have in cache, no guarantee; - if set to non zero, then the result is at least as fresh as given rv.",
+						"name": "resourceVersion",
+						"in": "query"
+					},
+					{
+						"uniqueItems": true,
+						"type": "integer",
+						"description": "Timeout for the list/watch call.",
+						"name": "timeoutSeconds",
+						"in": "query"
+					},
+					{
+						"uniqueItems": true,
+						"type": "boolean",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"name": "watch",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+						}
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "kubeflow.org",
+					"version": "v1alpha2",
+					"kind": "TFJob"
+				}
+			},
+			"parameters": [
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "object name and auth scope, such as for teams and projects",
+					"name": "namespace",
+					"in": "path",
+					"required": true
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "If 'true', then the output is pretty printed.",
+					"name": "pretty",
+					"in": "query"
+				}
+			]
+		},
+		"/apis/kubeflow.org/v1alpha2/namespaces/{namespace}/tfjobs/{name}": {
+			"get": {
+				"description": "read the specified TFJob",
+				"consumes": [
+					"*/*"
+				],
+				"produces": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf"
+				],
+				"schemes": [
+					"https"
+				],
+				"tags": [
+					"kubeflowOrg_v1alpha2"
+				],
+				"operationId": "readKubeflowOrgV1alpha2NamespacedTFJob",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJob"
+						}
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "kubeflow.org",
+					"version": "v1alpha2",
+					"kind": "TFJob"
+				}
+			},
+			"put": {
+				"description": "replace the specified TFJob",
+				"consumes": [
+					"*/*"
+				],
+				"produces": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf"
+				],
+				"schemes": [
+					"https"
+				],
+				"tags": [
+					"kubeflowOrg_v1alpha2"
+				],
+				"operationId": "replaceKubeflowOrgV1alpha2NamespacedTFJob",
+				"parameters": [
+					{
+						"name": "body",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJob"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJob"
+						}
+					},
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJob"
+						}
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "kubeflow.org",
+					"version": "v1alpha2",
+					"kind": "TFJob"
+				}
+			},
+			"delete": {
+				"description": "delete a TFJob",
+				"consumes": [
+					"*/*"
+				],
+				"produces": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf"
+				],
+				"schemes": [
+					"https"
+				],
+				"tags": [
+					"kubeflowOrg_v1alpha2"
+				],
+				"operationId": "deleteKubeflowOrgV1alpha2NamespacedTFJob",
+				"parameters": [
+					{
+						"name": "body",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+						}
+					},
+					{
+						"uniqueItems": true,
+						"type": "integer",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"name": "gracePeriodSeconds",
+						"in": "query"
+					},
+					{
+						"uniqueItems": true,
+						"type": "boolean",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"name": "orphanDependents",
+						"in": "query"
+					},
+					{
+						"uniqueItems": true,
+						"type": "string",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"name": "propagationPolicy",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+						}
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "kubeflow.org",
+					"version": "v1alpha2",
+					"kind": "TFJob"
+				}
+			},
+			"patch": {
+				"description": "partially update the specified TFJob",
+				"consumes": [
+					"application/json-patch+json",
+					"application/merge-patch+json",
+					"application/strategic-merge-patch+json"
+				],
+				"produces": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf"
+				],
+				"schemes": [
+					"https"
+				],
+				"tags": [
+					"kubeflowOrg_v1alpha2"
+				],
+				"operationId": "patchKubeflowOrgV1alpha2NamespacedTFJob",
+				"parameters": [
+					{
+						"name": "body",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJob"
+						}
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "kubeflow.org",
+					"version": "v1alpha2",
+					"kind": "TFJob"
+				}
+			},
+			"parameters": [
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "name of the TFJob",
+					"name": "name",
+					"in": "path",
+					"required": true
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "object name and auth scope, such as for teams and projects",
+					"name": "namespace",
+					"in": "path",
+					"required": true
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "If 'true', then the output is pretty printed.",
+					"name": "pretty",
+					"in": "query"
+				}
+			]
+		},
+		"/apis/kubeflow.org/v1alpha2/tfjobs": {
+			"get": {
+				"description": "list or watch objects of kind TFJob",
+				"consumes": [
+					"*/*"
+				],
+				"produces": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf",
+					"application/json;stream=watch",
+					"application/vnd.kubernetes.protobuf;stream=watch"
+				],
+				"schemes": [
+					"https"
+				],
+				"tags": [
+					"kubeflowOrg_v1alpha2"
+				],
+				"operationId": "listKubeflowOrgV1alpha2TFJobForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJobList"
+						}
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "kubeflow.org",
+					"version": "v1alpha2",
+					"kind": "TFJob"
+				}
+			},
+			"parameters": [
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"name": "continue",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"name": "fieldSelector",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "boolean",
+					"description": "If true, partially initialized resources are included in the response.",
+					"name": "includeUninitialized",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"name": "labelSelector",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "integer",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"name": "limit",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "If 'true', then the output is pretty printed.",
+					"name": "pretty",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history. When specified for list: - if unset, then the result is returned from remote storage based on quorum-read flag; - if it's 0, then we simply return what we currently have in cache, no guarantee; - if set to non zero, then the result is at least as fresh as given rv.",
+					"name": "resourceVersion",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "integer",
+					"description": "Timeout for the list/watch call.",
+					"name": "timeoutSeconds",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "boolean",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"name": "watch",
+					"in": "query"
+				}
+			]
+		},
+		"/apis/kubeflow.org/v1alpha2/watch/namespaces/{namespace}/tfjobs": {
+			"get": {
+				"description": "watch individual changes to a list of TFJob",
+				"consumes": [
+					"*/*"
+				],
+				"produces": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf",
+					"application/json;stream=watch",
+					"application/vnd.kubernetes.protobuf;stream=watch"
+				],
+				"schemes": [
+					"https"
+				],
+				"tags": [
+					"kubeflowOrg_v1alpha2"
+				],
+				"operationId": "watchKubeflowOrgV1alpha2NamespacedTFJobList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+						}
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "kubeflow.org",
+					"version": "v1alpha2",
+					"kind": "TFJob"
+				}
+			},
+			"parameters": [
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"name": "continue",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"name": "fieldSelector",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "boolean",
+					"description": "If true, partially initialized resources are included in the response.",
+					"name": "includeUninitialized",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"name": "labelSelector",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "integer",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"name": "limit",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "object name and auth scope, such as for teams and projects",
+					"name": "namespace",
+					"in": "path",
+					"required": true
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "If 'true', then the output is pretty printed.",
+					"name": "pretty",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history. When specified for list: - if unset, then the result is returned from remote storage based on quorum-read flag; - if it's 0, then we simply return what we currently have in cache, no guarantee; - if set to non zero, then the result is at least as fresh as given rv.",
+					"name": "resourceVersion",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "integer",
+					"description": "Timeout for the list/watch call.",
+					"name": "timeoutSeconds",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "boolean",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"name": "watch",
+					"in": "query"
+				}
+			]
+		},
+		"/apis/kubeflow.org/v1alpha2/watch/namespaces/{namespace}/tfjobs/{name}": {
+			"get": {
+				"description": "watch changes to an object of kind TFJob",
+				"consumes": [
+					"*/*"
+				],
+				"produces": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf",
+					"application/json;stream=watch",
+					"application/vnd.kubernetes.protobuf;stream=watch"
+				],
+				"schemes": [
+					"https"
+				],
+				"tags": [
+					"kubeflowOrg_v1alpha2"
+				],
+				"operationId": "watchKubeflowOrgV1alpha2NamespacedTFJob",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+						}
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "kubeflow.org",
+					"version": "v1alpha2",
+					"kind": "TFJob"
+				}
+			},
+			"parameters": [
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"name": "continue",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"name": "fieldSelector",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "boolean",
+					"description": "If true, partially initialized resources are included in the response.",
+					"name": "includeUninitialized",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"name": "labelSelector",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "integer",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"name": "limit",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "name of the TFJob",
+					"name": "name",
+					"in": "path",
+					"required": true
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "object name and auth scope, such as for teams and projects",
+					"name": "namespace",
+					"in": "path",
+					"required": true
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "If 'true', then the output is pretty printed.",
+					"name": "pretty",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history. When specified for list: - if unset, then the result is returned from remote storage based on quorum-read flag; - if it's 0, then we simply return what we currently have in cache, no guarantee; - if set to non zero, then the result is at least as fresh as given rv.",
+					"name": "resourceVersion",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "integer",
+					"description": "Timeout for the list/watch call.",
+					"name": "timeoutSeconds",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "boolean",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"name": "watch",
+					"in": "query"
+				}
+			]
+		},
+		"/apis/kubeflow.org/v1alpha2/watch/tfjobs": {
+			"get": {
+				"description": "watch individual changes to a list of TFJob",
+				"consumes": [
+					"*/*"
+				],
+				"produces": [
+					"application/json",
+					"application/yaml",
+					"application/vnd.kubernetes.protobuf",
+					"application/json;stream=watch",
+					"application/vnd.kubernetes.protobuf;stream=watch"
+				],
+				"schemes": [
+					"https"
+				],
+				"tags": [
+					"kubeflowOrg_v1alpha2"
+				],
+				"operationId": "watchKubeflowOrgV1alpha2TFJobListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+						}
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "kubeflow.org",
+					"version": "v1alpha2",
+					"kind": "TFJob"
+				}
+			},
+			"parameters": [
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server the server will respond with a 410 ResourceExpired error indicating the client must restart their list without the continue field. This field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"name": "continue",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"name": "fieldSelector",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "boolean",
+					"description": "If true, partially initialized resources are included in the response.",
+					"name": "includeUninitialized",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"name": "labelSelector",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "integer",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"name": "limit",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "If 'true', then the output is pretty printed.",
+					"name": "pretty",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "string",
+					"description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history. When specified for list: - if unset, then the result is returned from remote storage based on quorum-read flag; - if it's 0, then we simply return what we currently have in cache, no guarantee; - if set to non zero, then the result is at least as fresh as given rv.",
+					"name": "resourceVersion",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "integer",
+					"description": "Timeout for the list/watch call.",
+					"name": "timeoutSeconds",
+					"in": "query"
+				},
+				{
+					"uniqueItems": true,
+					"type": "boolean",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"name": "watch",
+					"in": "query"
+				}
+			]
+		}
+	},
+	"definitions": {
+		"com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJob": {
+			"description": "TFJob represents the configuration of signal TFJob",
+			"properties": {
+				"apiVersion": {
+					"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+					"type": "string"
+				},
+				"kind": {
+					"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+					"type": "string"
+				},
+				"metadata": {
+					"description": "Standard object's metadata.",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+				},
+				"spec": {
+					"description": "Specification of the desired behavior of the TFJob.",
+					"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJobSpec"
+				},
+				"status": {
+					"description": "Most recently observed status of the TFJob. This data may not be up to date. Populated by the system. Read-only.",
+					"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJobStatus"
+				}
+			},
+			"x-kubernetes-group-version-kind": [
+				{
+					"group": "kubeflow.org",
+					"version": "v1alpha2",
+					"kind": "TFJob"
+				}
+			]
+		},
+		"com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJobCondition": {
+			"description": "TFJobCondition describes the state of the TFJob at a certain point.",
+			"required": [
+				"type",
+				"status"
+			],
+			"properties": {
+				"lastTransitionTime": {
+					"description": "Last time the condition transitioned from one status to another.",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+				},
+				"lastUpdateTime": {
+					"description": "The last time this condition was updated.",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+				},
+				"message": {
+					"description": "A human readable message indicating details about the transition.",
+					"type": "string"
+				},
+				"reason": {
+					"description": "The reason for the condition's last transition.",
+					"type": "string"
+				},
+				"status": {
+					"description": "Status of the condition, one of True, False, Unknown.",
+					"type": "string"
+				},
+				"type": {
+					"description": "Type of TFJob condition.",
+					"type": "string"
+				}
+			}
+		},
+		"com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJobList": {
+			"description": "TFJobList is a list of TFJobs.",
+			"required": [
+				"items"
+			],
+			"properties": {
+				"apiVersion": {
+					"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+					"type": "string"
+				},
+				"items": {
+					"description": "List of TFJobs.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJob"
+					}
+				},
+				"kind": {
+					"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+					"type": "string"
+				},
+				"metadata": {
+					"description": "Standard list metadata.",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+				}
+			},
+			"x-kubernetes-group-version-kind": [
+				{
+					"group": "kubeflow.org",
+					"version": "v1alpha2",
+					"kind": "TFJobList"
+				}
+			]
+		},
+		"com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJobSpec": {
+			"description": "TFJobSpec is a desired state description of the TFJob.",
+			"required": [
+				"tfReplicaSpecs"
+			],
+			"properties": {
+				"cleanPodPolicy": {
+					"description": "CleanPodPolicy defines the policy to kill pods after TFJob is succeeded. Default to Running.",
+					"type": "string"
+				},
+				"tfReplicaSpecs": {
+					"description": "TFReplicaSpecs is map of TFReplicaType and TFReplicaSpec specifies the TF replicas to run. For example,\n  {\n    \"PS\": TFReplicaSpec,\n    \"Worker\": TFReplicaSpec,\n  }",
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFReplicaSpec"
+					}
+				}
+			}
+		},
+		"com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJobStatus": {
+			"description": "TFJobStatus represents the current observed state of the TFJob.",
+			"required": [
+				"conditions",
+				"tfReplicaStatuses"
+			],
+			"properties": {
+				"completionTime": {
+					"description": "Represents time when the TFJob was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+				},
+				"conditions": {
+					"description": "Conditions is an array of current observed TFJob conditions.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFJobCondition"
+					}
+				},
+				"lastReconcileTime": {
+					"description": "Represents last time when the TFJob was reconciled. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+				},
+				"startTime": {
+					"description": "Represents time when the TFJob was acknowledged by the TFJob controller. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+				},
+				"tfReplicaStatuses": {
+					"description": "TFReplicaStatuses is map of TFReplicaType and TFReplicaStatus, specifies the status of each TFReplica.",
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/definitions/com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFReplicaStatus"
+					}
+				}
+			}
+		},
+		"com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFReplicaSpec": {
+			"description": "TFReplicaSpec is a description of the TFReplica",
+			"properties": {
+				"replicas": {
+					"description": "Replicas is the desired number of replicas of the given template. If unspecified, defaults to 1.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"restartPolicy": {
+					"description": "Restart policy for all TFReplicas within the TFJob. One of Always, OnFailure, Never and ExitCode. Default to Never.",
+					"type": "string"
+				},
+				"template": {
+					"description": "Template is the object that describes the pod that will be created for this TFReplica. RestartPolicy in PodTemplateSpec will be overide by RestartPolicy in TFReplicaSpec",
+					"$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec"
+				}
+			}
+		},
+		"com.github.kubeflow.tf-operator.pkg.apis.tensorflow.v1alpha2.TFReplicaStatus": {
+			"description": "TFReplicaStatus represents the current observed state of the TFReplica.",
+			"properties": {
+				"active": {
+					"description": "The number of actively running pods.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"failed": {
+					"description": "The number of pods which reached phase Failed.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"succeeded": {
+					"description": "The number of pods which reached phase Succeeded.",
+					"type": "integer",
+					"format": "int32"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource": {
+			"description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
+			"required": [
+				"volumeID"
+			],
+			"properties": {
+				"fsType": {
+					"description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+					"type": "string"
+				},
+				"partition": {
+					"description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+					"type": "integer",
+					"format": "int32"
+				},
+				"readOnly": {
+					"description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+					"type": "boolean"
+				},
+				"volumeID": {
+					"description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.Affinity": {
+			"description": "Affinity is a group of affinity scheduling rules.",
+			"properties": {
+				"nodeAffinity": {
+					"description": "Describes node affinity scheduling rules for the pod.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.NodeAffinity"
+				},
+				"podAffinity": {
+					"description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+					"$ref": "#/definitions/io.k8s.api.core.v1.PodAffinity"
+				},
+				"podAntiAffinity": {
+					"description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+					"$ref": "#/definitions/io.k8s.api.core.v1.PodAntiAffinity"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.AzureDiskVolumeSource": {
+			"description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+			"required": [
+				"diskName",
+				"diskURI"
+			],
+			"properties": {
+				"cachingMode": {
+					"description": "Host Caching mode: None, Read Only, Read Write.",
+					"type": "string"
+				},
+				"diskName": {
+					"description": "The Name of the data disk in the blob storage",
+					"type": "string"
+				},
+				"diskURI": {
+					"description": "The URI the data disk in the blob storage",
+					"type": "string"
+				},
+				"fsType": {
+					"description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+					"type": "string"
+				},
+				"kind": {
+					"description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+					"type": "string"
+				},
+				"readOnly": {
+					"description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+					"type": "boolean"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.AzureFileVolumeSource": {
+			"description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+			"required": [
+				"secretName",
+				"shareName"
+			],
+			"properties": {
+				"readOnly": {
+					"description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+					"type": "boolean"
+				},
+				"secretName": {
+					"description": "the name of secret that contains Azure Storage Account Name and Key",
+					"type": "string"
+				},
+				"shareName": {
+					"description": "Share Name",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.Capabilities": {
+			"description": "Adds and removes POSIX capabilities from running containers.",
+			"properties": {
+				"add": {
+					"description": "Added capabilities",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"drop": {
+					"description": "Removed capabilities",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"io.k8s.api.core.v1.CephFSVolumeSource": {
+			"description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
+			"required": [
+				"monitors"
+			],
+			"properties": {
+				"monitors": {
+					"description": "Required: Monitors is a collection of Ceph monitors More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"path": {
+					"description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+					"type": "string"
+				},
+				"readOnly": {
+					"description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+					"type": "boolean"
+				},
+				"secretFile": {
+					"description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+					"type": "string"
+				},
+				"secretRef": {
+					"description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+					"$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+				},
+				"user": {
+					"description": "Optional: User is the rados user name, default is admin More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.CinderVolumeSource": {
+			"description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
+			"required": [
+				"volumeID"
+			],
+			"properties": {
+				"fsType": {
+					"description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+					"type": "string"
+				},
+				"readOnly": {
+					"description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+					"type": "boolean"
+				},
+				"volumeID": {
+					"description": "volume id used to identify the volume in cinder More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.ConfigMapEnvSource": {
+			"description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+			"properties": {
+				"name": {
+					"description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+					"type": "string"
+				},
+				"optional": {
+					"description": "Specify whether the ConfigMap must be defined",
+					"type": "boolean"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.ConfigMapKeySelector": {
+			"description": "Selects a key from a ConfigMap.",
+			"required": [
+				"key"
+			],
+			"properties": {
+				"key": {
+					"description": "The key to select.",
+					"type": "string"
+				},
+				"name": {
+					"description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+					"type": "string"
+				},
+				"optional": {
+					"description": "Specify whether the ConfigMap or it's key must be defined",
+					"type": "boolean"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.ConfigMapProjection": {
+			"description": "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
+			"properties": {
+				"items": {
+					"description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+					}
+				},
+				"name": {
+					"description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+					"type": "string"
+				},
+				"optional": {
+					"description": "Specify whether the ConfigMap or it's keys must be defined",
+					"type": "boolean"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.ConfigMapVolumeSource": {
+			"description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
+			"properties": {
+				"defaultMode": {
+					"description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"items": {
+					"description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+					}
+				},
+				"name": {
+					"description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+					"type": "string"
+				},
+				"optional": {
+					"description": "Specify whether the ConfigMap or it's keys must be defined",
+					"type": "boolean"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.Container": {
+			"description": "A single application container that you want to run within a pod.",
+			"required": [
+				"name"
+			],
+			"properties": {
+				"args": {
+					"description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"command": {
+					"description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"env": {
+					"description": "List of environment variables to set in the container. Cannot be updated.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
+					},
+					"x-kubernetes-patch-merge-key": "name",
+					"x-kubernetes-patch-strategy": "merge"
+				},
+				"envFrom": {
+					"description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.EnvFromSource"
+					}
+				},
+				"image": {
+					"description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+					"type": "string"
+				},
+				"imagePullPolicy": {
+					"description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+					"type": "string"
+				},
+				"lifecycle": {
+					"description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.Lifecycle"
+				},
+				"livenessProbe": {
+					"description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+					"$ref": "#/definitions/io.k8s.api.core.v1.Probe"
+				},
+				"name": {
+					"description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+					"type": "string"
+				},
+				"ports": {
+					"description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.ContainerPort"
+					},
+					"x-kubernetes-patch-merge-key": "containerPort",
+					"x-kubernetes-patch-strategy": "merge"
+				},
+				"readinessProbe": {
+					"description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+					"$ref": "#/definitions/io.k8s.api.core.v1.Probe"
+				},
+				"resources": {
+					"description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+					"$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+				},
+				"securityContext": {
+					"description": "Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+					"$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext"
+				},
+				"stdin": {
+					"description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+					"type": "boolean"
+				},
+				"stdinOnce": {
+					"description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+					"type": "boolean"
+				},
+				"terminationMessagePath": {
+					"description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+					"type": "string"
+				},
+				"terminationMessagePolicy": {
+					"description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+					"type": "string"
+				},
+				"tty": {
+					"description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+					"type": "boolean"
+				},
+				"volumeDevices": {
+					"description": "volumeDevices is the list of block devices to be used by the container. This is an alpha feature and may change in the future.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.VolumeDevice"
+					},
+					"x-kubernetes-patch-merge-key": "devicePath",
+					"x-kubernetes-patch-strategy": "merge"
+				},
+				"volumeMounts": {
+					"description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
+					},
+					"x-kubernetes-patch-merge-key": "mountPath",
+					"x-kubernetes-patch-strategy": "merge"
+				},
+				"workingDir": {
+					"description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.ContainerPort": {
+			"description": "ContainerPort represents a network port in a single container.",
+			"required": [
+				"containerPort"
+			],
+			"properties": {
+				"containerPort": {
+					"description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 \u003c x \u003c 65536.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"hostIP": {
+					"description": "What host IP to bind the external port to.",
+					"type": "string"
+				},
+				"hostPort": {
+					"description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 \u003c x \u003c 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"name": {
+					"description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+					"type": "string"
+				},
+				"protocol": {
+					"description": "Protocol for port. Must be UDP or TCP. Defaults to \"TCP\".",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.DownwardAPIProjection": {
+			"description": "Represents downward API info for projecting into a projected volume. Note that this is identical to a downwardAPI volume source without the default mode.",
+			"properties": {
+				"items": {
+					"description": "Items is a list of DownwardAPIVolume file",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
+					}
+				}
+			}
+		},
+		"io.k8s.api.core.v1.DownwardAPIVolumeFile": {
+			"description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+			"required": [
+				"path"
+			],
+			"properties": {
+				"fieldRef": {
+					"description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector"
+				},
+				"mode": {
+					"description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"path": {
+					"description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+					"type": "string"
+				},
+				"resourceFieldRef": {
+					"description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+			"description": "DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.",
+			"properties": {
+				"defaultMode": {
+					"description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"items": {
+					"description": "Items is a list of downward API volume file",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
+					}
+				}
+			}
+		},
+		"io.k8s.api.core.v1.EmptyDirVolumeSource": {
+			"description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
+			"properties": {
+				"medium": {
+					"description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+					"type": "string"
+				},
+				"sizeLimit": {
+					"description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.EnvFromSource": {
+			"description": "EnvFromSource represents the source of a set of ConfigMaps",
+			"properties": {
+				"configMapRef": {
+					"description": "The ConfigMap to select from",
+					"$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource"
+				},
+				"prefix": {
+					"description": "An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+					"type": "string"
+				},
+				"secretRef": {
+					"description": "The Secret to select from",
+					"$ref": "#/definitions/io.k8s.api.core.v1.SecretEnvSource"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.EnvVar": {
+			"description": "EnvVar represents an environment variable present in a Container.",
+			"required": [
+				"name"
+			],
+			"properties": {
+				"name": {
+					"description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+					"type": "string"
+				},
+				"value": {
+					"description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+					"type": "string"
+				},
+				"valueFrom": {
+					"description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.EnvVarSource"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.EnvVarSource": {
+			"description": "EnvVarSource represents a source for the value of an EnvVar.",
+			"properties": {
+				"configMapKeyRef": {
+					"description": "Selects a key of a ConfigMap.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapKeySelector"
+				},
+				"fieldRef": {
+					"description": "Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector"
+				},
+				"resourceFieldRef": {
+					"description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector"
+				},
+				"secretKeyRef": {
+					"description": "Selects a key of a secret in the pod's namespace",
+					"$ref": "#/definitions/io.k8s.api.core.v1.SecretKeySelector"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.ExecAction": {
+			"description": "ExecAction describes a \"run in container\" action.",
+			"properties": {
+				"command": {
+					"description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"io.k8s.api.core.v1.FCVolumeSource": {
+			"description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
+			"properties": {
+				"fsType": {
+					"description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+					"type": "string"
+				},
+				"lun": {
+					"description": "Optional: FC target lun number",
+					"type": "integer",
+					"format": "int32"
+				},
+				"readOnly": {
+					"description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+					"type": "boolean"
+				},
+				"targetWWNs": {
+					"description": "Optional: FC target worldwide names (WWNs)",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"wwids": {
+					"description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"io.k8s.api.core.v1.FlexVolumeSource": {
+			"description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+			"required": [
+				"driver"
+			],
+			"properties": {
+				"driver": {
+					"description": "Driver is the name of the driver to use for this volume.",
+					"type": "string"
+				},
+				"fsType": {
+					"description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+					"type": "string"
+				},
+				"options": {
+					"description": "Optional: Extra command options if any.",
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
+				},
+				"readOnly": {
+					"description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+					"type": "boolean"
+				},
+				"secretRef": {
+					"description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.FlockerVolumeSource": {
+			"description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
+			"properties": {
+				"datasetName": {
+					"description": "Name of the dataset stored as metadata -\u003e name on the dataset for Flocker should be considered as deprecated",
+					"type": "string"
+				},
+				"datasetUUID": {
+					"description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.GCEPersistentDiskVolumeSource": {
+			"description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
+			"required": [
+				"pdName"
+			],
+			"properties": {
+				"fsType": {
+					"description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+					"type": "string"
+				},
+				"partition": {
+					"description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+					"type": "integer",
+					"format": "int32"
+				},
+				"pdName": {
+					"description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+					"type": "string"
+				},
+				"readOnly": {
+					"description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+					"type": "boolean"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.GitRepoVolumeSource": {
+			"description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.",
+			"required": [
+				"repository"
+			],
+			"properties": {
+				"directory": {
+					"description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+					"type": "string"
+				},
+				"repository": {
+					"description": "Repository URL",
+					"type": "string"
+				},
+				"revision": {
+					"description": "Commit hash for the specified revision.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.GlusterfsVolumeSource": {
+			"description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
+			"required": [
+				"endpoints",
+				"path"
+			],
+			"properties": {
+				"endpoints": {
+					"description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
+					"type": "string"
+				},
+				"path": {
+					"description": "Path is the Glusterfs volume path. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
+					"type": "string"
+				},
+				"readOnly": {
+					"description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
+					"type": "boolean"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.HTTPGetAction": {
+			"description": "HTTPGetAction describes an action based on HTTP Get requests.",
+			"required": [
+				"port"
+			],
+			"properties": {
+				"host": {
+					"description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+					"type": "string"
+				},
+				"httpHeaders": {
+					"description": "Custom headers to set in the request. HTTP allows repeated headers.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.HTTPHeader"
+					}
+				},
+				"path": {
+					"description": "Path to access on the HTTP server.",
+					"type": "string"
+				},
+				"port": {
+					"description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
+				},
+				"scheme": {
+					"description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.HTTPHeader": {
+			"description": "HTTPHeader describes a custom header to be used in HTTP probes",
+			"required": [
+				"name",
+				"value"
+			],
+			"properties": {
+				"name": {
+					"description": "The header field name",
+					"type": "string"
+				},
+				"value": {
+					"description": "The header field value",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.Handler": {
+			"description": "Handler defines a specific action that should be taken",
+			"properties": {
+				"exec": {
+					"description": "One and only one of the following should be specified. Exec specifies the action to take.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.ExecAction"
+				},
+				"httpGet": {
+					"description": "HTTPGet specifies the http request to perform.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction"
+				},
+				"tcpSocket": {
+					"description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported",
+					"$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.HostAlias": {
+			"description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
+			"properties": {
+				"hostnames": {
+					"description": "Hostnames for the above IP address.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"ip": {
+					"description": "IP address of the host file entry.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.HostPathVolumeSource": {
+			"description": "Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.",
+			"required": [
+				"path"
+			],
+			"properties": {
+				"path": {
+					"description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+					"type": "string"
+				},
+				"type": {
+					"description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.ISCSIVolumeSource": {
+			"description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
+			"required": [
+				"targetPortal",
+				"iqn",
+				"lun"
+			],
+			"properties": {
+				"chapAuthDiscovery": {
+					"description": "whether support iSCSI Discovery CHAP authentication",
+					"type": "boolean"
+				},
+				"chapAuthSession": {
+					"description": "whether support iSCSI Session CHAP authentication",
+					"type": "boolean"
+				},
+				"fsType": {
+					"description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+					"type": "string"
+				},
+				"initiatorName": {
+					"description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface \u003ctarget portal\u003e:\u003cvolume name\u003e will be created for the connection.",
+					"type": "string"
+				},
+				"iqn": {
+					"description": "Target iSCSI Qualified Name.",
+					"type": "string"
+				},
+				"iscsiInterface": {
+					"description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+					"type": "string"
+				},
+				"lun": {
+					"description": "iSCSI Target Lun number.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"portals": {
+					"description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"readOnly": {
+					"description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+					"type": "boolean"
+				},
+				"secretRef": {
+					"description": "CHAP Secret for iSCSI target and initiator authentication",
+					"$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+				},
+				"targetPortal": {
+					"description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.KeyToPath": {
+			"description": "Maps a string key to a path within a volume.",
+			"required": [
+				"key",
+				"path"
+			],
+			"properties": {
+				"key": {
+					"description": "The key to project.",
+					"type": "string"
+				},
+				"mode": {
+					"description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"path": {
+					"description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.Lifecycle": {
+			"description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
+			"properties": {
+				"postStart": {
+					"description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+					"$ref": "#/definitions/io.k8s.api.core.v1.Handler"
+				},
+				"preStop": {
+					"description": "PreStop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+					"$ref": "#/definitions/io.k8s.api.core.v1.Handler"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.LocalObjectReference": {
+			"description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+			"properties": {
+				"name": {
+					"description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.NFSVolumeSource": {
+			"description": "Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.",
+			"required": [
+				"server",
+				"path"
+			],
+			"properties": {
+				"path": {
+					"description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+					"type": "string"
+				},
+				"readOnly": {
+					"description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+					"type": "boolean"
+				},
+				"server": {
+					"description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.NodeAffinity": {
+			"description": "Node affinity is a group of node affinity scheduling rules.",
+			"properties": {
+				"preferredDuringSchedulingIgnoredDuringExecution": {
+					"description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.PreferredSchedulingTerm"
+					}
+				},
+				"requiredDuringSchedulingIgnoredDuringExecution": {
+					"description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.NodeSelector": {
+			"description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
+			"required": [
+				"nodeSelectorTerms"
+			],
+			"properties": {
+				"nodeSelectorTerms": {
+					"description": "Required. A list of node selector terms. The terms are ORed.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorTerm"
+					}
+				}
+			}
+		},
+		"io.k8s.api.core.v1.NodeSelectorRequirement": {
+			"description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+			"required": [
+				"key",
+				"operator"
+			],
+			"properties": {
+				"key": {
+					"description": "The label key that the selector applies to.",
+					"type": "string"
+				},
+				"operator": {
+					"description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+					"type": "string"
+				},
+				"values": {
+					"description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"io.k8s.api.core.v1.NodeSelectorTerm": {
+			"description": "A null or empty node selector term matches no objects.",
+			"required": [
+				"matchExpressions"
+			],
+			"properties": {
+				"matchExpressions": {
+					"description": "Required. A list of node selector requirements. The requirements are ANDed.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
+					}
+				}
+			}
+		},
+		"io.k8s.api.core.v1.ObjectFieldSelector": {
+			"description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+			"required": [
+				"fieldPath"
+			],
+			"properties": {
+				"apiVersion": {
+					"description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+					"type": "string"
+				},
+				"fieldPath": {
+					"description": "Path of the field to select in the specified API version.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource": {
+			"description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
+			"required": [
+				"claimName"
+			],
+			"properties": {
+				"claimName": {
+					"description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+					"type": "string"
+				},
+				"readOnly": {
+					"description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+					"type": "boolean"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource": {
+			"description": "Represents a Photon Controller persistent disk resource.",
+			"required": [
+				"pdID"
+			],
+			"properties": {
+				"fsType": {
+					"description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+					"type": "string"
+				},
+				"pdID": {
+					"description": "ID that identifies Photon Controller persistent disk",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.PodAffinity": {
+			"description": "Pod affinity is a group of inter pod affinity scheduling rules.",
+			"properties": {
+				"preferredDuringSchedulingIgnoredDuringExecution": {
+					"description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
+					}
+				},
+				"requiredDuringSchedulingIgnoredDuringExecution": {
+					"description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
+					}
+				}
+			}
+		},
+		"io.k8s.api.core.v1.PodAffinityTerm": {
+			"description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+			"required": [
+				"topologyKey"
+			],
+			"properties": {
+				"labelSelector": {
+					"description": "A label query over a set of resources, in this case pods.",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+				},
+				"namespaces": {
+					"description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"topologyKey": {
+					"description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.PodAntiAffinity": {
+			"description": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
+			"properties": {
+				"preferredDuringSchedulingIgnoredDuringExecution": {
+					"description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
+					}
+				},
+				"requiredDuringSchedulingIgnoredDuringExecution": {
+					"description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
+					}
+				}
+			}
+		},
+		"io.k8s.api.core.v1.PodDNSConfig": {
+			"description": "PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.",
+			"properties": {
+				"nameservers": {
+					"description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"options": {
+					"description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.PodDNSConfigOption"
+					}
+				},
+				"searches": {
+					"description": "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"io.k8s.api.core.v1.PodDNSConfigOption": {
+			"description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+			"properties": {
+				"name": {
+					"description": "Required.",
+					"type": "string"
+				},
+				"value": {
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.PodSecurityContext": {
+			"description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+			"properties": {
+				"fsGroup": {
+					"description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.",
+					"type": "integer",
+					"format": "int64"
+				},
+				"runAsNonRoot": {
+					"description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+					"type": "boolean"
+				},
+				"runAsUser": {
+					"description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+					"type": "integer",
+					"format": "int64"
+				},
+				"seLinuxOptions": {
+					"description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions"
+				},
+				"supplementalGroups": {
+					"description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.",
+					"type": "array",
+					"items": {
+						"type": "integer",
+						"format": "int64"
+					}
+				}
+			}
+		},
+		"io.k8s.api.core.v1.PodSpec": {
+			"description": "PodSpec is a description of a pod.",
+			"required": [
+				"containers"
+			],
+			"properties": {
+				"activeDeadlineSeconds": {
+					"description": "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
+					"type": "integer",
+					"format": "int64"
+				},
+				"affinity": {
+					"description": "If specified, the pod's scheduling constraints",
+					"$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
+				},
+				"automountServiceAccountToken": {
+					"description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
+					"type": "boolean"
+				},
+				"containers": {
+					"description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.Container"
+					},
+					"x-kubernetes-patch-merge-key": "name",
+					"x-kubernetes-patch-strategy": "merge"
+				},
+				"dnsConfig": {
+					"description": "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy. This is an alpha feature introduced in v1.9 and CustomPodDNS feature gate must be enabled to use it.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.PodDNSConfig"
+				},
+				"dnsPolicy": {
+					"description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'. Note that 'None' policy is an alpha feature introduced in v1.9 and CustomPodDNS feature gate must be enabled to use it.",
+					"type": "string"
+				},
+				"hostAliases": {
+					"description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.HostAlias"
+					},
+					"x-kubernetes-patch-merge-key": "ip",
+					"x-kubernetes-patch-strategy": "merge"
+				},
+				"hostIPC": {
+					"description": "Use the host's ipc namespace. Optional: Default to false.",
+					"type": "boolean"
+				},
+				"hostNetwork": {
+					"description": "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.",
+					"type": "boolean"
+				},
+				"hostPID": {
+					"description": "Use the host's pid namespace. Optional: Default to false.",
+					"type": "boolean"
+				},
+				"hostname": {
+					"description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
+					"type": "string"
+				},
+				"imagePullSecrets": {
+					"description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+					},
+					"x-kubernetes-patch-merge-key": "name",
+					"x-kubernetes-patch-strategy": "merge"
+				},
+				"initContainers": {
+					"description": "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, or Liveness probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.Container"
+					},
+					"x-kubernetes-patch-merge-key": "name",
+					"x-kubernetes-patch-strategy": "merge"
+				},
+				"nodeName": {
+					"description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.",
+					"type": "string"
+				},
+				"nodeSelector": {
+					"description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
+				},
+				"priority": {
+					"description": "The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"priorityClassName": {
+					"description": "If specified, indicates the pod's priority. \"SYSTEM\" is a special keyword which indicates the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+					"type": "string"
+				},
+				"restartPolicy": {
+					"description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy",
+					"type": "string"
+				},
+				"schedulerName": {
+					"description": "If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.",
+					"type": "string"
+				},
+				"securityContext": {
+					"description": "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext"
+				},
+				"serviceAccount": {
+					"description": "DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.",
+					"type": "string"
+				},
+				"serviceAccountName": {
+					"description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+					"type": "string"
+				},
+				"subdomain": {
+					"description": "If specified, the fully qualified Pod hostname will be \"\u003chostname\u003e.\u003csubdomain\u003e.\u003cpod namespace\u003e.svc.\u003ccluster domain\u003e\". If not specified, the pod will not have a domainname at all.",
+					"type": "string"
+				},
+				"terminationGracePeriodSeconds": {
+					"description": "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.",
+					"type": "integer",
+					"format": "int64"
+				},
+				"tolerations": {
+					"description": "If specified, the pod's tolerations.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
+					}
+				},
+				"volumes": {
+					"description": "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.Volume"
+					},
+					"x-kubernetes-patch-merge-key": "name",
+					"x-kubernetes-patch-strategy": "merge,retainKeys"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.PodTemplateSpec": {
+			"description": "PodTemplateSpec describes the data a pod should have when created from a template",
+			"properties": {
+				"metadata": {
+					"description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+				},
+				"spec": {
+					"description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+					"$ref": "#/definitions/io.k8s.api.core.v1.PodSpec"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.PortworxVolumeSource": {
+			"description": "PortworxVolumeSource represents a Portworx volume resource.",
+			"required": [
+				"volumeID"
+			],
+			"properties": {
+				"fsType": {
+					"description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+					"type": "string"
+				},
+				"readOnly": {
+					"description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+					"type": "boolean"
+				},
+				"volumeID": {
+					"description": "VolumeID uniquely identifies a Portworx volume",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.PreferredSchedulingTerm": {
+			"description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+			"required": [
+				"weight",
+				"preference"
+			],
+			"properties": {
+				"preference": {
+					"description": "A node selector term, associated with the corresponding weight.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorTerm"
+				},
+				"weight": {
+					"description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+					"type": "integer",
+					"format": "int32"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.Probe": {
+			"description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+			"properties": {
+				"exec": {
+					"description": "One and only one of the following should be specified. Exec specifies the action to take.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.ExecAction"
+				},
+				"failureThreshold": {
+					"description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"httpGet": {
+					"description": "HTTPGet specifies the http request to perform.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction"
+				},
+				"initialDelaySeconds": {
+					"description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+					"type": "integer",
+					"format": "int32"
+				},
+				"periodSeconds": {
+					"description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"successThreshold": {
+					"description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"tcpSocket": {
+					"description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported",
+					"$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction"
+				},
+				"timeoutSeconds": {
+					"description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+					"type": "integer",
+					"format": "int32"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.ProjectedVolumeSource": {
+			"description": "Represents a projected volume source",
+			"required": [
+				"sources"
+			],
+			"properties": {
+				"defaultMode": {
+					"description": "Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"sources": {
+					"description": "list of volume projections",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.VolumeProjection"
+					}
+				}
+			}
+		},
+		"io.k8s.api.core.v1.QuobyteVolumeSource": {
+			"description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
+			"required": [
+				"registry",
+				"volume"
+			],
+			"properties": {
+				"group": {
+					"description": "Group to map volume access to Default is no group",
+					"type": "string"
+				},
+				"readOnly": {
+					"description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+					"type": "boolean"
+				},
+				"registry": {
+					"description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+					"type": "string"
+				},
+				"user": {
+					"description": "User to map volume access to Defaults to serivceaccount user",
+					"type": "string"
+				},
+				"volume": {
+					"description": "Volume is a string that references an already created Quobyte volume by name.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.RBDVolumeSource": {
+			"description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
+			"required": [
+				"monitors",
+				"image"
+			],
+			"properties": {
+				"fsType": {
+					"description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+					"type": "string"
+				},
+				"image": {
+					"description": "The rados image name. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+					"type": "string"
+				},
+				"keyring": {
+					"description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+					"type": "string"
+				},
+				"monitors": {
+					"description": "A collection of Ceph monitors. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"pool": {
+					"description": "The rados pool name. Default is rbd. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+					"type": "string"
+				},
+				"readOnly": {
+					"description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+					"type": "boolean"
+				},
+				"secretRef": {
+					"description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+					"$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+				},
+				"user": {
+					"description": "The rados user name. Default is admin. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.ResourceFieldSelector": {
+			"description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+			"required": [
+				"resource"
+			],
+			"properties": {
+				"containerName": {
+					"description": "Container name: required for volumes, optional for env vars",
+					"type": "string"
+				},
+				"divisor": {
+					"description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+				},
+				"resource": {
+					"description": "Required: resource to select",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.ResourceRequirements": {
+			"description": "ResourceRequirements describes the compute resource requirements.",
+			"properties": {
+				"limits": {
+					"description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+					}
+				},
+				"requests": {
+					"description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+					}
+				}
+			}
+		},
+		"io.k8s.api.core.v1.SELinuxOptions": {
+			"description": "SELinuxOptions are the labels to be applied to the container",
+			"properties": {
+				"level": {
+					"description": "Level is SELinux level label that applies to the container.",
+					"type": "string"
+				},
+				"role": {
+					"description": "Role is a SELinux role label that applies to the container.",
+					"type": "string"
+				},
+				"type": {
+					"description": "Type is a SELinux type label that applies to the container.",
+					"type": "string"
+				},
+				"user": {
+					"description": "User is a SELinux user label that applies to the container.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.ScaleIOVolumeSource": {
+			"description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
+			"required": [
+				"gateway",
+				"system",
+				"secretRef"
+			],
+			"properties": {
+				"fsType": {
+					"description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+					"type": "string"
+				},
+				"gateway": {
+					"description": "The host address of the ScaleIO API Gateway.",
+					"type": "string"
+				},
+				"protectionDomain": {
+					"description": "The name of the ScaleIO Protection Domain for the configured storage.",
+					"type": "string"
+				},
+				"readOnly": {
+					"description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+					"type": "boolean"
+				},
+				"secretRef": {
+					"description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+				},
+				"sslEnabled": {
+					"description": "Flag to enable/disable SSL communication with Gateway, default false",
+					"type": "boolean"
+				},
+				"storageMode": {
+					"description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.",
+					"type": "string"
+				},
+				"storagePool": {
+					"description": "The ScaleIO Storage Pool associated with the protection domain.",
+					"type": "string"
+				},
+				"system": {
+					"description": "The name of the storage system as configured in ScaleIO.",
+					"type": "string"
+				},
+				"volumeName": {
+					"description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.SecretEnvSource": {
+			"description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
+			"properties": {
+				"name": {
+					"description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+					"type": "string"
+				},
+				"optional": {
+					"description": "Specify whether the Secret must be defined",
+					"type": "boolean"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.SecretKeySelector": {
+			"description": "SecretKeySelector selects a key of a Secret.",
+			"required": [
+				"key"
+			],
+			"properties": {
+				"key": {
+					"description": "The key of the secret to select from.  Must be a valid secret key.",
+					"type": "string"
+				},
+				"name": {
+					"description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+					"type": "string"
+				},
+				"optional": {
+					"description": "Specify whether the Secret or it's key must be defined",
+					"type": "boolean"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.SecretProjection": {
+			"description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
+			"properties": {
+				"items": {
+					"description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+					}
+				},
+				"name": {
+					"description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+					"type": "string"
+				},
+				"optional": {
+					"description": "Specify whether the Secret or its key must be defined",
+					"type": "boolean"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.SecretVolumeSource": {
+			"description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
+			"properties": {
+				"defaultMode": {
+					"description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"items": {
+					"description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+					}
+				},
+				"optional": {
+					"description": "Specify whether the Secret or it's keys must be defined",
+					"type": "boolean"
+				},
+				"secretName": {
+					"description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.SecurityContext": {
+			"description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+			"properties": {
+				"allowPrivilegeEscalation": {
+					"description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+					"type": "boolean"
+				},
+				"capabilities": {
+					"description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.Capabilities"
+				},
+				"privileged": {
+					"description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+					"type": "boolean"
+				},
+				"readOnlyRootFilesystem": {
+					"description": "Whether this container has a read-only root filesystem. Default is false.",
+					"type": "boolean"
+				},
+				"runAsNonRoot": {
+					"description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+					"type": "boolean"
+				},
+				"runAsUser": {
+					"description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+					"type": "integer",
+					"format": "int64"
+				},
+				"seLinuxOptions": {
+					"description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.StorageOSVolumeSource": {
+			"description": "Represents a StorageOS persistent volume resource.",
+			"properties": {
+				"fsType": {
+					"description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+					"type": "string"
+				},
+				"readOnly": {
+					"description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+					"type": "boolean"
+				},
+				"secretRef": {
+					"description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+				},
+				"volumeName": {
+					"description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+					"type": "string"
+				},
+				"volumeNamespace": {
+					"description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.TCPSocketAction": {
+			"description": "TCPSocketAction describes an action based on opening a socket",
+			"required": [
+				"port"
+			],
+			"properties": {
+				"host": {
+					"description": "Optional: Host name to connect to, defaults to the pod IP.",
+					"type": "string"
+				},
+				"port": {
+					"description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.Toleration": {
+			"description": "The pod this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+			"properties": {
+				"effect": {
+					"description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+					"type": "string"
+				},
+				"key": {
+					"description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+					"type": "string"
+				},
+				"operator": {
+					"description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+					"type": "string"
+				},
+				"tolerationSeconds": {
+					"description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+					"type": "integer",
+					"format": "int64"
+				},
+				"value": {
+					"description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.Volume": {
+			"description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+			"required": [
+				"name"
+			],
+			"properties": {
+				"awsElasticBlockStore": {
+					"description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+					"$ref": "#/definitions/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource"
+				},
+				"azureDisk": {
+					"description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.AzureDiskVolumeSource"
+				},
+				"azureFile": {
+					"description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.AzureFileVolumeSource"
+				},
+				"cephfs": {
+					"description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+					"$ref": "#/definitions/io.k8s.api.core.v1.CephFSVolumeSource"
+				},
+				"cinder": {
+					"description": "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+					"$ref": "#/definitions/io.k8s.api.core.v1.CinderVolumeSource"
+				},
+				"configMap": {
+					"description": "ConfigMap represents a configMap that should populate this volume",
+					"$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapVolumeSource"
+				},
+				"downwardAPI": {
+					"description": "DownwardAPI represents downward API about the pod that should populate this volume",
+					"$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeSource"
+				},
+				"emptyDir": {
+					"description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+					"$ref": "#/definitions/io.k8s.api.core.v1.EmptyDirVolumeSource"
+				},
+				"fc": {
+					"description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.FCVolumeSource"
+				},
+				"flexVolume": {
+					"description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.FlexVolumeSource"
+				},
+				"flocker": {
+					"description": "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+					"$ref": "#/definitions/io.k8s.api.core.v1.FlockerVolumeSource"
+				},
+				"gcePersistentDisk": {
+					"description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+					"$ref": "#/definitions/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource"
+				},
+				"gitRepo": {
+					"description": "GitRepo represents a git repository at a particular revision.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.GitRepoVolumeSource"
+				},
+				"glusterfs": {
+					"description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md",
+					"$ref": "#/definitions/io.k8s.api.core.v1.GlusterfsVolumeSource"
+				},
+				"hostPath": {
+					"description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+					"$ref": "#/definitions/io.k8s.api.core.v1.HostPathVolumeSource"
+				},
+				"iscsi": {
+					"description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://releases.k8s.io/HEAD/examples/volumes/iscsi/README.md",
+					"$ref": "#/definitions/io.k8s.api.core.v1.ISCSIVolumeSource"
+				},
+				"name": {
+					"description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+					"type": "string"
+				},
+				"nfs": {
+					"description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+					"$ref": "#/definitions/io.k8s.api.core.v1.NFSVolumeSource"
+				},
+				"persistentVolumeClaim": {
+					"description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+					"$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource"
+				},
+				"photonPersistentDisk": {
+					"description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+					"$ref": "#/definitions/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource"
+				},
+				"portworxVolume": {
+					"description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+					"$ref": "#/definitions/io.k8s.api.core.v1.PortworxVolumeSource"
+				},
+				"projected": {
+					"description": "Items for all in one resources secrets, configmaps, and downward API",
+					"$ref": "#/definitions/io.k8s.api.core.v1.ProjectedVolumeSource"
+				},
+				"quobyte": {
+					"description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+					"$ref": "#/definitions/io.k8s.api.core.v1.QuobyteVolumeSource"
+				},
+				"rbd": {
+					"description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md",
+					"$ref": "#/definitions/io.k8s.api.core.v1.RBDVolumeSource"
+				},
+				"scaleIO": {
+					"description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.ScaleIOVolumeSource"
+				},
+				"secret": {
+					"description": "Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+					"$ref": "#/definitions/io.k8s.api.core.v1.SecretVolumeSource"
+				},
+				"storageos": {
+					"description": "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.StorageOSVolumeSource"
+				},
+				"vsphereVolume": {
+					"description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+					"$ref": "#/definitions/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.VolumeDevice": {
+			"description": "volumeDevice describes a mapping of a raw block device within a container.",
+			"required": [
+				"name",
+				"devicePath"
+			],
+			"properties": {
+				"devicePath": {
+					"description": "devicePath is the path inside of the container that the device will be mapped to.",
+					"type": "string"
+				},
+				"name": {
+					"description": "name must match the name of a persistentVolumeClaim in the pod",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.VolumeMount": {
+			"description": "VolumeMount describes a mounting of a Volume within a container.",
+			"required": [
+				"name",
+				"mountPath"
+			],
+			"properties": {
+				"mountPath": {
+					"description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+					"type": "string"
+				},
+				"mountPropagation": {
+					"description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationHostToContainer is used. This field is alpha in 1.8 and can be reworked or removed in a future release.",
+					"type": "string"
+				},
+				"name": {
+					"description": "This must match the Name of a Volume.",
+					"type": "string"
+				},
+				"readOnly": {
+					"description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+					"type": "boolean"
+				},
+				"subPath": {
+					"description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.VolumeProjection": {
+			"description": "Projection that may be projected along with other supported volume types",
+			"properties": {
+				"configMap": {
+					"description": "information about the configMap data to project",
+					"$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapProjection"
+				},
+				"downwardAPI": {
+					"description": "information about the downwardAPI data to project",
+					"$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIProjection"
+				},
+				"secret": {
+					"description": "information about the secret data to project",
+					"$ref": "#/definitions/io.k8s.api.core.v1.SecretProjection"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource": {
+			"description": "Represents a vSphere volume resource.",
+			"required": [
+				"volumePath"
+			],
+			"properties": {
+				"fsType": {
+					"description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+					"type": "string"
+				},
+				"storagePolicyID": {
+					"description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+					"type": "string"
+				},
+				"storagePolicyName": {
+					"description": "Storage Policy Based Management (SPBM) profile name.",
+					"type": "string"
+				},
+				"volumePath": {
+					"description": "Path that identifies vSphere volume vmdk",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+			"description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+			"required": [
+				"weight",
+				"podAffinityTerm"
+			],
+			"properties": {
+				"podAffinityTerm": {
+					"description": "Required. A pod affinity term, associated with the corresponding weight.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
+				},
+				"weight": {
+					"description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+					"type": "integer",
+					"format": "int32"
+				}
+			}
+		},
+		"io.k8s.apimachinery.pkg.api.resource.Quantity": {
+			"type": "string"
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup": {
+			"description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+			"required": [
+				"name",
+				"versions",
+				"serverAddressByClientCIDRs"
+			],
+			"properties": {
+				"apiVersion": {
+					"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+					"type": "string"
+				},
+				"kind": {
+					"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+					"type": "string"
+				},
+				"name": {
+					"description": "name is the name of the group.",
+					"type": "string"
+				},
+				"preferredVersion": {
+					"description": "preferredVersion is the version preferred by the API server, which probably is the storage version.",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
+				},
+				"serverAddressByClientCIDRs": {
+					"description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
+					}
+				},
+				"versions": {
+					"description": "versions are the versions supported in this group.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
+					}
+				}
+			},
+			"x-kubernetes-group-version-kind": [
+				{
+					"group": "",
+					"version": "v1",
+					"kind": "APIGroup"
+				}
+			]
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList": {
+			"description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
+			"required": [
+				"groups"
+			],
+			"properties": {
+				"apiVersion": {
+					"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+					"type": "string"
+				},
+				"groups": {
+					"description": "groups is a list of APIGroup.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+					}
+				},
+				"kind": {
+					"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+					"type": "string"
+				}
+			},
+			"x-kubernetes-group-version-kind": [
+				{
+					"group": "",
+					"version": "v1",
+					"kind": "APIGroupList"
+				}
+			]
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
+			"description": "APIResource specifies the name of a resource and whether it is namespaced.",
+			"required": [
+				"name",
+				"singularName",
+				"namespaced",
+				"kind",
+				"verbs"
+			],
+			"properties": {
+				"categories": {
+					"description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"group": {
+					"description": "group is the preferred group of the resource.  Empty implies the group of the containing resource list. For subresources, this may have a different value, for example: Scale\".",
+					"type": "string"
+				},
+				"kind": {
+					"description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')",
+					"type": "string"
+				},
+				"name": {
+					"description": "name is the plural name of the resource.",
+					"type": "string"
+				},
+				"namespaced": {
+					"description": "namespaced indicates if a resource is namespaced or not.",
+					"type": "boolean"
+				},
+				"shortNames": {
+					"description": "shortNames is a list of suggested short names of the resource.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"singularName": {
+					"description": "singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface.",
+					"type": "string"
+				},
+				"verbs": {
+					"description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"version": {
+					"description": "version is the preferred version of the resource.  Empty implies the version of the containing resource list For subresources, this may have a different value, for example: v1 (while inside a v1beta1 version of the core resource's group)\".",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+			"description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+			"required": [
+				"groupVersion",
+				"resources"
+			],
+			"properties": {
+				"apiVersion": {
+					"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+					"type": "string"
+				},
+				"groupVersion": {
+					"description": "groupVersion is the group and version this APIResourceList is for.",
+					"type": "string"
+				},
+				"kind": {
+					"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+					"type": "string"
+				},
+				"resources": {
+					"description": "resources contains the name of the resources and if they are namespaced.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"
+					}
+				}
+			},
+			"x-kubernetes-group-version-kind": [
+				{
+					"group": "",
+					"version": "v1",
+					"kind": "APIResourceList"
+				}
+			]
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
+			"description": "DeleteOptions may be provided when deleting an API object.",
+			"properties": {
+				"apiVersion": {
+					"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+					"type": "string"
+				},
+				"gracePeriodSeconds": {
+					"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+					"type": "integer",
+					"format": "int64"
+				},
+				"kind": {
+					"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+					"type": "string"
+				},
+				"orphanDependents": {
+					"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+					"type": "boolean"
+				},
+				"preconditions": {
+					"description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions"
+				},
+				"propagationPolicy": {
+					"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+					"type": "string"
+				}
+			},
+			"x-kubernetes-group-version-kind": [
+				{
+					"group": "",
+					"version": "v1",
+					"kind": "DeleteOptions"
+				},
+				{
+					"group": "kubeflow.org",
+					"version": "v1alpha2",
+					"kind": "DeleteOptions"
+				}
+			]
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery": {
+			"description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+			"required": [
+				"groupVersion",
+				"version"
+			],
+			"properties": {
+				"groupVersion": {
+					"description": "groupVersion specifies the API group and version in the form \"group/version\"",
+					"type": "string"
+				},
+				"version": {
+					"description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.Initializer": {
+			"description": "Initializer is information about an initializer that has not yet completed.",
+			"required": [
+				"name"
+			],
+			"properties": {
+				"name": {
+					"description": "name of the process that is responsible for initializing this object.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.Initializers": {
+			"description": "Initializers tracks the progress of initialization.",
+			"required": [
+				"pending"
+			],
+			"properties": {
+				"pending": {
+					"description": "Pending is a list of initializers that must execute in order before this object is visible. When the last pending initializer is removed, and no failing result is set, the initializers struct will be set to nil and the object is considered as initialized and visible to all clients.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Initializer"
+					},
+					"x-kubernetes-patch-merge-key": "name",
+					"x-kubernetes-patch-strategy": "merge"
+				},
+				"result": {
+					"description": "If result is set with the Failure field, the object will be persisted to storage and then deleted, ensuring that other clients can observe the deletion.",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+				}
+			}
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+			"description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+			"properties": {
+				"matchExpressions": {
+					"description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+					}
+				},
+				"matchLabels": {
+					"description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+			"description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+			"required": [
+				"key",
+				"operator"
+			],
+			"properties": {
+				"key": {
+					"description": "key is the label key that the selector applies to.",
+					"type": "string",
+					"x-kubernetes-patch-merge-key": "key",
+					"x-kubernetes-patch-strategy": "merge"
+				},
+				"operator": {
+					"description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+					"type": "string"
+				},
+				"values": {
+					"description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
+			"description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+			"properties": {
+				"continue": {
+					"description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response.",
+					"type": "string"
+				},
+				"resourceVersion": {
+					"description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+					"type": "string"
+				},
+				"selfLink": {
+					"description": "selfLink is a URL representing this object. Populated by the system. Read-only.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+			"description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+			"properties": {
+				"annotations": {
+					"description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
+				},
+				"clusterName": {
+					"description": "The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.",
+					"type": "string"
+				},
+				"creationTimestamp": {
+					"description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+				},
+				"deletionGracePeriodSeconds": {
+					"description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+					"type": "integer",
+					"format": "int64"
+				},
+				"deletionTimestamp": {
+					"description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+				},
+				"finalizers": {
+					"description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"x-kubernetes-patch-strategy": "merge"
+				},
+				"generateName": {
+					"description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency",
+					"type": "string"
+				},
+				"generation": {
+					"description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+					"type": "integer",
+					"format": "int64"
+				},
+				"initializers": {
+					"description": "An initializer is a controller which enforces some system invariant at object creation time. This field is a list of initializers that have not yet acted on this object. If nil or empty, this object has been completely initialized. Otherwise, the object is considered uninitialized and is hidden (in list/watch and get calls) from clients that haven't explicitly asked to observe uninitialized objects.\n\nWhen an object is created, the system will populate this list with the current set of initializers. Only privileged users may set or modify this list. Once it is empty, it may not be modified further by any user.",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Initializers"
+				},
+				"labels": {
+					"description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
+				},
+				"name": {
+					"description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+					"type": "string"
+				},
+				"namespace": {
+					"description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+					"type": "string"
+				},
+				"ownerReferences": {
+					"description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
+					},
+					"x-kubernetes-patch-merge-key": "uid",
+					"x-kubernetes-patch-strategy": "merge"
+				},
+				"resourceVersion": {
+					"description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+					"type": "string"
+				},
+				"selfLink": {
+					"description": "SelfLink is a URL representing this object. Populated by the system. Read-only.",
+					"type": "string"
+				},
+				"uid": {
+					"description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
+			"description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+			"required": [
+				"apiVersion",
+				"kind",
+				"name",
+				"uid"
+			],
+			"properties": {
+				"apiVersion": {
+					"description": "API version of the referent.",
+					"type": "string"
+				},
+				"blockOwnerDeletion": {
+					"description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+					"type": "boolean"
+				},
+				"controller": {
+					"description": "If true, this reference points to the managing controller.",
+					"type": "boolean"
+				},
+				"kind": {
+					"description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+					"type": "string"
+				},
+				"name": {
+					"description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+					"type": "string"
+				},
+				"uid": {
+					"description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
+			"description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body."
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions": {
+			"description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
+			"properties": {
+				"uid": {
+					"description": "Specifies the target UID.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR": {
+			"description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
+			"required": [
+				"clientCIDR",
+				"serverAddress"
+			],
+			"properties": {
+				"clientCIDR": {
+					"description": "The CIDR with which clients can match their IP to figure out the server address that they should use.",
+					"type": "string"
+				},
+				"serverAddress": {
+					"description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+			"description": "Status is a return value for calls that don't return other objects.",
+			"properties": {
+				"apiVersion": {
+					"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+					"type": "string"
+				},
+				"code": {
+					"description": "Suggested HTTP return code for this status, 0 if not set.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"details": {
+					"description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails"
+				},
+				"kind": {
+					"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+					"type": "string"
+				},
+				"message": {
+					"description": "A human-readable description of the status of this operation.",
+					"type": "string"
+				},
+				"metadata": {
+					"description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+				},
+				"reason": {
+					"description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+					"type": "string"
+				},
+				"status": {
+					"description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+					"type": "string"
+				}
+			},
+			"x-kubernetes-group-version-kind": [
+				{
+					"group": "",
+					"version": "v1",
+					"kind": "Status"
+				}
+			]
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause": {
+			"description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+			"properties": {
+				"field": {
+					"description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+					"type": "string"
+				},
+				"message": {
+					"description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+					"type": "string"
+				},
+				"reason": {
+					"description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+			"description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+			"properties": {
+				"causes": {
+					"description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
+					}
+				},
+				"group": {
+					"description": "The group attribute of the resource associated with the status StatusReason.",
+					"type": "string"
+				},
+				"kind": {
+					"description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+					"type": "string"
+				},
+				"name": {
+					"description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+					"type": "string"
+				},
+				"retryAfterSeconds": {
+					"description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+					"type": "integer",
+					"format": "int32"
+				},
+				"uid": {
+					"description": "UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+			"description": "Event represents a single event to a watched resource.",
+			"required": [
+				"type",
+				"object"
+			],
+			"properties": {
+				"object": {
+					"description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
+					"$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension"
+				},
+				"type": {
+					"type": "string"
+				}
+			},
+			"x-kubernetes-group-version-kind": [
+				{
+					"group": "",
+					"version": "v1",
+					"kind": "WatchEvent"
+				},
+				{
+					"group": "kubeflow.org",
+					"version": "v1alpha2",
+					"kind": "WatchEvent"
+				}
+			]
+		},
+		"io.k8s.apimachinery.pkg.runtime.RawExtension": {
+			"description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.Object `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// External package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// On the wire, the JSON will look something like this: {\n\t\"kind\":\"MyAPIObject\",\n\t\"apiVersion\":\"v1\",\n\t\"myPlugin\": {\n\t\t\"kind\":\"PluginA\",\n\t\t\"aOption\":\"foo\",\n\t},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
+			"required": [
+				"Raw"
+			],
+			"properties": {
+				"Raw": {
+					"description": "Raw is the underlying serialization of this object.",
+					"type": "string",
+					"format": "byte"
+				}
+			}
+		},
+		"io.k8s.apimachinery.pkg.util.intstr.IntOrString": {
+			"type": "string",
+			"format": "int-or-string"
+		}
+	}
+}


### PR DESCRIPTION
Should we maintain model spec `swagger.json` in this repo ? or in [kubeflow/tfjob](https://github.com/kubeflow/tf-operator) ?

If we maintain it in this repo, I will create a PR to [kubeflow-incubator/gen](https://github.com/kubeflow-incubator/gen), for easy access to local specification instead of fetching from github.

Signed-off-by: JetMuffin <mofeng.cj@alibaba-inc.com>